### PR TITLE
VIZ-189

### DIFF
--- a/loader/common/tree_loader.py
+++ b/loader/common/tree_loader.py
@@ -235,13 +235,10 @@ class TreeLoader(AnalysisLoader):
 
 
     def _get_max_height_from_node(self, tree, node):
-        try:
-            path_lengths = nx.shortest_path_length(tree, source=node)
-            node_with_longest_path = max(path_lengths.keys(), key=lambda key: path_lengths[key])
+        path_lengths = nx.shortest_path_length(tree, source=node)
+        node_with_longest_path = max(path_lengths.keys(), key=lambda key: path_lengths[key])
 
-            return path_lengths[node_with_longest_path]
-        except KeyError:
-            return 0
+        return path_lengths[node_with_longest_path]
 
 
 

--- a/loader/common/tree_loader.py
+++ b/loader/common/tree_loader.py
@@ -70,7 +70,7 @@ class TreeLoader(AnalysisLoader):
         return [tree, tree_root, ordering]
 
     def _transform_data(self, tree, tree_root, ordering):
-        todo_list = [[tree_root, 'root']]
+        todo_list = [[tree_root, None]]
         heatmap_index = 0
         data = []
 

--- a/src/tree.js
+++ b/src/tree.js
@@ -39,7 +39,7 @@ export const resolvers = {
           size: 1,
           query: {
             bool: {
-              filter: [{ term: { parent: "root" } }]
+              filter: [{ term: { cell_id: "root" } }]
             }
           }
         }

--- a/src/tree.js
+++ b/src/tree.js
@@ -11,7 +11,7 @@ export const schema = gql`
 
   type Node {
     id: [String!]!
-    parent: String!
+    parent: String
     index: Int!
     maxIndex: Int!
     maxHeight: Int!


### PR DESCRIPTION
Currently existing odd tree behaviour is caused by odd data, ie. the root in OV2295 has 12 children, 11 of which are internal nodes with no further children (heights of 0, thus being classified as leaf nodes by our code).